### PR TITLE
fix: "Trust anchor for certification path not found." on Android version 9 device

### DIFF
--- a/scripts/tinyapp.js
+++ b/scripts/tinyapp.js
@@ -6,7 +6,7 @@ Java.perform(function () {
     // webview 证书绑定
     const H5WebViewClient = Java.use('com.alipay.mobile.nebulacore.web.H5WebViewClient');
     const SslErrorHandler = Java.use("android.webkit.SslErrorHandler");
-    H5WebViewClient.onReceivedSslError.implementation = function(webview, sslHandler, sslError){
+    H5WebViewClient.onReceivedSslError.implementation = function (webview, sslHandler, sslError) {
         console.log('H5WebViewClient onReceivedSslError called, proceed');
         var handler = Java.cast(sslHandler, SslErrorHandler);
         handler.proceed();
@@ -20,10 +20,47 @@ Java.perform(function () {
 
     // disable ssl hostname check
     const AbstractVerifier = Java.use("org.apache.http.conn.ssl.AbstractVerifier");
-    AbstractVerifier.verify.overload('java.lang.String', '[Ljava.lang.String;', '[Ljava.lang.String;', 'boolean').implementation=function(a,b,c,d){
+    AbstractVerifier.verify.overload('java.lang.String', '[Ljava.lang.String;', '[Ljava.lang.String;', 'boolean').implementation = function (a, b, c, d) {
         console.log('HostnameVerifier wants to verify ', a, ' disabled');
         return;
     };
+
+    // disable ssl check
+    const X509TrustManager = Java.use('javax.net.ssl.X509TrustManager');
+    const SSLContext = Java.use('javax.net.ssl.SSLContext');
+    const SecureRandom = Java.use('java.security.SecureRandom');
+    const HostnameVerifier = Java.use("javax.net.ssl.HostnameVerifier");
+    const HttpsURLConnection = Java.use("javax.net.ssl.HttpsURLConnection");
+
+    var MyTrustManager = Java.registerClass({
+        name: 'com.example.MyTrustManager',
+        implements: [X509TrustManager],
+        methods: {
+            checkClientTrusted: function (chain, authType) {
+            },
+            checkServerTrusted: function (chain, authType) {
+            },
+            getAcceptedIssuers: function () {
+                return [];
+            },
+        }
+    });
+    var sc = SSLContext.getInstance("TLS");
+    sc.init(null, Java.array('com.example.MyTrustManager', [MyTrustManager.$new()]), SecureRandom.$new());
+    HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+    var MyHostnameVerifier = Java.registerClass({
+        name: 'com.example.MyHostnameVerifier',
+        implements: [HostnameVerifier],
+        methods: {
+            verify: function (hostname, session) {
+                return true;
+            },
+        }
+    });
+
+    HttpsURLConnection.setDefaultHostnameVerifier(MyHostnameVerifier.$new());
+
 
     console.log('injected');
 });


### PR DESCRIPTION
On my device(Nexus 5, Android 9, sdk version 28), the network request will be interrupted due to an exception:
```
javax.net.ssl.SSLHandshakeException: 
java.security.cert.CertPathValidatorException: 
Trust anchor for certification path not found.
```

I fixed this problem by initializing a custom `X509TrustManager` and set custom `HostnameVerifier`.
Tested on my device.